### PR TITLE
Add inbound feedback integration

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,3 @@
 module.exports = {
-  inbound: {
-    verbose: require('./lib/verbose')
-  }
+  inbound: require('./lib/inbound')
 };

--- a/package.json
+++ b/package.json
@@ -17,9 +17,15 @@
     "prepublish": "cake build"
   },
   "dependencies": {
+    "@activeprospect/indexer": "^1.3.1",
+    "dotaccess": "^1.0.5",
     "flat": "^1.3.0",
     "leadconduit-default": "^2.7.1",
-    "lodash": "^2.4.1"
+    "leadconduit-integration": "^0.2.0",
+    "lodash": "^2.4.2",
+    "mime-content": "0.0.7",
+    "mimeparse": "^0.1.4",
+    "xmlbuilder": "^8.2.2"
   },
   "devDependencies": {
     "chai": ">= 1.9.0",

--- a/spec/inbound/feedback-spec.coffee
+++ b/spec/inbound/feedback-spec.coffee
@@ -1,0 +1,230 @@
+assert = require('chai').assert
+integration = require('../../src/inbound/feedback')
+
+
+
+describe 'Inbound feedback', ->
+
+  describe 'request', ->
+
+
+    it 'should not allow head', ->
+      assertMethodNotAllowed('head')
+
+
+    it 'should not allow put', ->
+      assertMethodNotAllowed('put')
+
+
+    it 'should not allow delete', ->
+      assertMethodNotAllowed('delete')
+
+
+    it 'should not allow patch', ->
+      assertMethodNotAllowed('patch')
+
+
+    it 'should handle GET', ->
+      request =
+        uri: 'https://app.leadconduit.com/feedback?event_id=12345&type=return&reason=Wrong+number'
+        method: 'GET'
+        headers:
+          'Accept': 'application/json'
+
+      assert.deepEqual integration.request(request),
+        type: 'return'
+        reason: 'Wrong number'
+
+
+    it 'should handle form POST', ->
+      body = 'type=return&reason=Wrong+number'
+
+      request =
+        uri: 'https://app.leadconduit.com/feedback?event_id=12345'
+        method: 'POST'
+        headers:
+          'Content-Type': 'application/x-www-form-urlencoded'
+          'Accept': 'application/json'
+          'Content-Length': Buffer.byteLength(body)
+        body: body
+
+      assert.deepEqual integration.request(request),
+        type: 'return'
+        reason: 'Wrong number'
+
+
+    it 'should handle XML', ->
+      body = """
+        <feedback>
+          <type>return</type>
+          <reason>Wrong number</reason>
+        </feedback>
+        """
+
+      request =
+        uri: 'https://app.leadconduit.com/feedback?event_id=12345'
+        method: 'POST'
+        headers:
+          'Content-Type': 'text/xml'
+          'Accept': 'text/xml'
+          'Content-Length': Buffer.byteLength(body)
+        body: body
+
+      assert.deepEqual integration.request(request),
+        type: 'return'
+        reason: 'Wrong number'
+
+
+    it 'should handle JSON', ->
+      body = """
+        {
+          "type": "return",
+          "reason": "Wrong number"
+        }
+        """
+
+      request =
+        uri: 'https://app.leadconduit.com/feedback?event_id=12345'
+        method: 'POST'
+        headers:
+          'Content-Type': 'application/json'
+          'Accept': 'application/json'
+          'Content-Length': Buffer.byteLength(body)
+        body: body
+
+      assert.deepEqual integration.request(request),
+        type: 'return'
+        reason: 'Wrong number'
+
+
+    it 'should handle malformed XML', ->
+      body = 'whatever'
+      request =
+        uri: 'https://app.leadconduit.com/feedback?event_id=12345'
+        method: 'POST'
+        headers:
+          'Content-Type': 'text/xml'
+          'Accept': 'text/xml'
+          'Content-Length': Buffer.byteLength(body)
+        body: body
+
+      try
+        integration.request(request)
+        assert.fail("expected an error to be thrown when xml content cannot be parsed")
+      catch e
+        assert.equal e.status, 400
+        assert.equal e.body, 'Body does not contain XML or XML is unparseable -- Error: Non-whitespace before first tag. Line: 0 Column: 1 Char: w.'
+        assert.deepEqual e.headers, 'Content-Type': 'text/plain'
+
+
+    it 'should handle malformed JSON', ->
+      body = 'whatever'
+
+      request =
+        uri: 'https://app.leadconduit.com/feedback?event_id=12345'
+        method: 'POST'
+        headers:
+          'Content-Type': 'application/json'
+          'Accept': 'application/json'
+          'Content-Length': Buffer.byteLength(body)
+        body: body
+
+      try
+        integration.request(request)
+        assert.fail("expected an error to be thrown when JSON content cannot be parsed")
+      catch e
+        assert.equal e.status, 400
+        assert.equal e.body, 'Body is not parsable as application/json -- Unexpected token w'
+        assert.deepEqual e.headers, 'Content-Type': 'text/plain'
+
+
+
+  describe 'response', ->
+
+    vars =
+      lead: { id: '123' }
+      outcome: 'failure'
+      reason: 'bad!'
+
+    it 'should respond with json', ->
+      res = integration.response(baseRequest('application/json'), vars)
+      assert.equal res.status, 201
+      assert.deepEqual res.headers, 'Content-Type': 'application/json', 'Content-Length': 79
+      assert.equal res.body, '{"outcome":"failure","reason":"bad!","lead":{"id":"123","email":"foo@bar.com"}}'
+
+
+    it 'should default to json', ->
+      res = integration.response(baseRequest('*/*'), vars)
+      assert.equal res.status, 201
+      assert.deepEqual res.headers['Content-Type'],  'application/json'
+
+
+    it 'should respond with text xml', ->
+      res = integration.response(baseRequest('text/xml'), vars)
+      assert.equal res.status, 201
+      assert.deepEqual res.headers, 'Content-Type': 'text/xml', 'Content-Length': 210
+      assert.equal res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n    <first_name/>\n    <last_name/>\n    <email>foo@bar.com</email>\n    <phone_1/>\n  </lead>\n</result>'
+
+
+    it 'should respond with application xml', ->
+      res = integration.response(baseRequest(), vars)
+      assert.equal res.status, 201
+      assert.deepEqual res.headers, 'Content-Type': 'application/xml', 'Content-Length': 210
+      assert.equal res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n    <first_name/>\n    <last_name/>\n    <email>foo@bar.com</email>\n    <phone_1/>\n  </lead>\n</result>'
+
+
+    describe 'With specified fields in response', ->
+
+      vars =
+        lead:
+          id: '123'
+          email: 'foo@bar.com'
+        outcome: 'failure'
+        reason: 'bad!'
+
+      it 'should respond with json', ->
+        res = integration.response(baseRequest('application/json'), vars, ['outcome', 'lead.id', 'lead.email'])
+        assert.equal res.status, 201
+        assert.equal res.headers['Content-Type'], 'application/json'
+        assert.equal res.body, '{"outcome":"failure","lead":{"id":"123","email":"foo@bar.com"}}'
+
+
+      it 'should respond with text xml', ->
+        res = integration.response(baseRequest('text/xml'), vars, ['outcome', 'lead.id', 'lead.email'])
+        assert.equal res.status, 201
+        assert.equal res.headers['Content-Type'], 'text/xml'
+        assert.equal res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <lead>\n    <id>123</id>\n    <email>foo@bar.com</email>\n  </lead>\n</result>'
+
+      it 'should respond with application xml', ->
+        res = integration.response(baseRequest(), vars, ['outcome', 'lead.id', 'lead.email'])
+        assert.equal res.status, 201
+        assert.equal res.headers['Content-Type'], 'application/xml'
+        assert.equal res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <lead>\n    <id>123</id>\n    <email>foo@bar.com</email>\n  </lead>\n</result>'
+
+
+
+#
+# Helpers ----------------------------------------------------------------
+#
+
+baseRequest = (accept = null, querystring = '') ->
+  uri: "/whatever#{querystring}"
+  method: 'post'
+  version: '1.1'
+  headers:
+    'Accept': accept ? 'application/xml'
+    'Content-Type': 'application/x-www-form-urlencoded'
+  body: 'first_name=Joe'
+  timestamp: new Date().getTime()
+
+
+assertMethodNotAllowed = (method) ->
+  try
+    integration.request(method: method)
+    assert.fail("expected #{method} to throw an error")
+  catch e
+    assert.equal e.status, 415
+    assert.equal e.body, "The #{method.toUpperCase()} method is not allowed"
+    assert.deepEqual e.headers,
+      'Allow': 'GET, POST'
+      'Content-Type': 'text/plain'

--- a/spec/inbound/verbose-spec.coffee
+++ b/spec/inbound/verbose-spec.coffee
@@ -1,5 +1,5 @@
 assert = require('chai').assert
-integration = require('../src/verbose')
+integration = require('../../src/inbound/verbose')
 types = require('leadconduit-types')
 
 describe 'Inbound Verbose Response', ->
@@ -17,6 +17,7 @@ describe 'Inbound Verbose Response', ->
             role_address: 'false'
             outcome: 'success'
 
+
   it 'should set appended fields correctly in JSON response', ->
     req =
       uri: 'http://example.com'
@@ -30,6 +31,7 @@ describe 'Inbound Verbose Response', ->
       body: '{"appended":{"briteverify":{"email":{"status":"valid","disposable":"false","role_address":"false","outcome":"success"}}},"outcome":"success","lead":{"id":"1234"}}'
     assert.deepEqual integration.response(req, @vars), expected
 
+
   it 'should set appended fields correctly in XML response', ->
     req =
       uri: 'http://example.com'
@@ -42,6 +44,7 @@ describe 'Inbound Verbose Response', ->
         'Content-Length': 359
       body: '<?xml version=\"1.0\"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n</result>'
     assert.deepEqual integration.response(req, @vars), expected
+
 
   it 'should respond correctly when no fields are appended', ->
     req =
@@ -59,6 +62,7 @@ describe 'Inbound Verbose Response', ->
         'Content-Length': 42
       body: '{"outcome":"success","lead":{"id":"1234"}}'
     assert.deepEqual integration.response(req, vars), expected
+
 
   it 'should respond correctly with rich appended fields', ->
     req =

--- a/src/inbound/feedback.coffee
+++ b/src/inbound/feedback.coffee
@@ -1,0 +1,178 @@
+_ = require('lodash')
+url = require('url')
+querystring = require('querystring')
+flat = require('flat')
+mimecontent = require('mime-content')
+mimeparse = require('mimeparse')
+xmlbuilder = require('xmlbuilder')
+dotaccess = require('dotaccess')
+HttpError = require('leadconduit-integration').HttpError
+
+supportedMimeTypes = [
+  'application/x-www-form-urlencoded',
+  'application/json',
+  'application/xml',
+  'text/xml'
+]
+
+supportedMimeTypeLookup = supportedMimeTypes.reduce(((lookup, mimeType) ->
+  lookup[mimeType] = true
+  lookup
+), {})
+
+
+request = (req) ->
+  # ensure supported method
+  method = req.method?.toLowerCase()
+  if method != 'get' and method != 'post'
+    throw new HttpError(415, { 'Content-Type': 'text/plain', Allow: 'GET, POST' }, "The #{method.toUpperCase()} method is not allowed")
+
+  # ensure acceptable content type, preferring JSON
+  mimeType = selectMimeType(req.headers['Accept'])
+  unless mimeType
+    throw new HttpError(406, { 'Content-Type': 'text/plain' }, "Not capable of generating content according to the Accept header")
+
+  feedbackVars = parseFeedbackVars(req)
+  delete feedbackVars.event_id
+  feedbackVars
+
+
+parseFeedbackVars = (req) ->
+  method = req.method?.toLowerCase()
+
+  # parse the query string
+  uri = url.parse(req.uri, true)
+  query = flat.unflatten(uri.query)
+
+  if method == 'get'
+    query
+
+  else if (method == 'post')
+
+    if req.headers['Content-Length']? or req.headers['Transfer-Encoding'] == 'chunked'
+      # assume a request body
+
+      # ensure a content type header
+      contentType = req.headers['Content-Type']
+      unless contentType
+        throw new HttpError(415, {'Content-Type': 'text/plain'}, 'Content-Type header is required')
+
+      # ensure valid mime type
+      mimeType = selectMimeType(req.headers['Content-Type'])
+      unless supportedMimeTypeLookup[mimeType]?
+        throw new HttpError(406, {'Content-Type': 'text/plain'}, "MIME type in Content-Type header is not supported. Use only #{supportedMimeTypes.join(', ')}.")
+
+      # parse request body according the the mime type
+      body = req.body?.trim()
+      return query unless body
+      try
+        parsed = mimecontent(body, mimeType)
+      catch e
+        throw new HttpError(400, { 'Content-Type': 'text/plain' }, "Body is not parsable as #{mimeType} -- #{e.message}")
+
+      # if form URL encoding, convert dot notation keys
+      if mimeType == 'application/x-www-form-urlencoded'
+        parsed = flat.unflatten(parsed)
+
+      # if XML, turn doc into an object
+      if mimeType == 'application/xml' or mimeType == 'text/xml'
+        try
+          parsed = parsed.toObject(explicitArray: false, explicitRoot: false, mergeAttrs: true)
+        catch e
+          xmlError = e.toString().replace(/\r?\n/g, " ")
+          throw new HttpError(400, {'Content-Type': 'text/plain'}, "Body does not contain XML or XML is unparseable -- #{xmlError}.")
+
+      # merge query string data into data parsed from request body
+      _.merge(parsed, query)
+
+      parsed
+
+    else
+      # assume no request body
+      query
+
+
+
+
+request.variables = ->
+  [
+    {
+      name: 'type'
+      label: 'Feedback type'
+      type: 'string'
+      description: 'The type of feedback being given'
+      examples: ['return', 'conversion']
+    }
+    {
+      name: 'reason'
+      label: 'Feedback reason'
+      type: 'string'
+      description: 'The reason the feedback is being given'
+      examples: ['Disconnected phone', 'Wrong number', 'Uncontactable', 'New customer']
+    }
+  ]
+
+
+#
+# Response Function ------------------------------------------------------
+#
+
+response = (req, vars, fieldIds = ['outcome', 'reason', 'lead.id', 'lead.first_name', 'lead.last_name', 'lead.email', 'lead.phone_1']) ->
+  mimeType = selectMimeType(req.headers['Accept'])
+
+  rtn = {}
+  for field in fieldIds
+    rtn[field] = dotaccess.get(vars, field)?.valueOf()
+  rtn = flat.unflatten(rtn)
+
+  body =
+    if mimeType == 'application/xml' or mimeType == 'text/xml'
+      xmlbuilder.create(result: rtn).end(pretty: true)
+    else if mimeType == 'application/json'
+      JSON.stringify(rtn)
+    else
+      lines = []
+      for fieldName, fieldValue of rtn
+        lines.push "#{fieldName.replace(/./g, '_')}:#{fieldValue ? ''}"
+      lines.join('\n')
+
+  headers =
+    'Content-Type': mimeType,
+    'Content-Length': Buffer.byteLength(body)
+
+  status: 201
+  headers: headers
+  body: body
+
+
+response.variables = ->
+  [
+    { name: 'outcome', type: 'string', description: 'The outcome of the feedback request (default is success, meaning that the feedback was accepted)' }
+    { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' }
+    { name: 'lead.id', type: 'string', description: 'The lead identifier' }
+    { name: 'lead.first_name', type: 'string', description: 'The consumer\'s first name' }
+    { name: 'lead.last_name', type: 'string', description: 'The consumer\'s last name' }
+    { name: 'lead.email', type: 'string', description: 'The consumer\'s email address' }
+    { name: 'lead.phone_1', type: 'string', description: 'The consumer\'s phone number' }
+  ]
+
+#
+# Helpers ----------------------------------------------------------------
+#
+
+selectMimeType = (contentType) ->
+  contentType = contentType or 'application/json'
+  contentType = 'application/json' if contentType == '*/*'
+  mimeparse.bestMatch(supportedMimeTypes, contentType)
+
+
+
+
+#
+# Exports ----------------------------------------------------------------
+#
+
+module.exports =
+  name: 'Standard Feedback'
+  request: request,
+  response: response

--- a/src/inbound/feedback.coffee
+++ b/src/inbound/feedback.coffee
@@ -1,6 +1,5 @@
 _ = require('lodash')
 url = require('url')
-querystring = require('querystring')
 flat = require('flat')
 mimecontent = require('mime-content')
 mimeparse = require('mimeparse')

--- a/src/inbound/index.coffee
+++ b/src/inbound/index.coffee
@@ -1,0 +1,1 @@
+module.exports = require('@activeprospect/indexer')(__dirname)

--- a/src/inbound/verbose.coffee
+++ b/src/inbound/verbose.coffee
@@ -30,5 +30,6 @@ response.variables = ->
 #
 
 module.exports =
+  name: 'Standard Verbose'
   request: inbound.request
   response: response


### PR DESCRIPTION
This integration is for use in the forthcoming "feedback" feature. It's purpose is to receive feedback from a recipient about a lead. Two types of feedback are supported by the handler: `return` and `conversion`. But this integration will pass through all feedback types.