### PR TITLE
capure price variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.0] - 2018-11-8
+### Added
+- Capture price variable
+
 ## [1.1.0] - 2018-02-26
 ### Added
 - Add classic inbound

--- a/lib/inbound/classic.js
+++ b/lib/inbound/classic.js
@@ -33,7 +33,8 @@ const buildXml = (vars) => {
 
   if (vars.reason) { xml.ele('reason', vars.reason); }
   xml.element('leadId', vars.lead.id).up()
-    .element('url').dat(url);
+    .element('url').dat(url).up()
+    .element('price', vars.price);
 
   return xml.end({pretty: true});
 };

--- a/lib/inbound/classic.js
+++ b/lib/inbound/classic.js
@@ -26,15 +26,16 @@ module.exports = {
 const buildXml = (vars) => {
 
   const url = `https://app.leadconduit.com/leads?id=${vars.lead.id}`;
+  const price = vars.price || 0;
   const xml = xmlbuilder
     .create('response', {headless: true})
     .dtd('https://app.leadconduit.com/dtd/response-v2-basic.dtd').up()
     .element('result', vars.outcome).up();
-
+    
   if (vars.reason) { xml.ele('reason', vars.reason); }
   xml.element('leadId', vars.lead.id).up()
     .element('url').dat(url).up()
-    .element('price', vars.price);
+    .element('price', price);
 
   return xml.end({pretty: true});
 };

--- a/lib/inbound/feedback.js
+++ b/lib/inbound/feedback.js
@@ -155,7 +155,7 @@ const response = (req, vars, fieldIds = ['outcome', 'reason', 'lead.id', 'lead.f
 response.variables = () => [
   { name: 'outcome', type: 'string', description: 'The outcome of the feedback request (default is success, meaning that the feedback was accepted)' },
   { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' },
-  { name: 'price', type: 'string', description: 'The price of the lead' },
+  { name: 'price', type: 'number', description: 'The price of the lead' },
   { name: 'lead.id', type: 'string', description: 'The lead identifier' },
   { name: 'lead.first_name', type: 'string', description: 'The consumer\'s first name' },
   { name: 'lead.last_name', type: 'string', description: 'The consumer\'s last name' },

--- a/lib/inbound/feedback.js
+++ b/lib/inbound/feedback.js
@@ -112,7 +112,7 @@ request.variables = () => [
   { name: 'reason', label: 'Feedback reason', type: 'string', description: 'The reason the feedback is being given', examples: ['Disconnected phone', 'Wrong number', 'Uncontactable', 'New customer']}
 ];
 
-const response = (req, vars, fieldIds = ['outcome', 'reason', 'lead.id', 'lead.first_name', 'lead.last_name', 'lead.email', 'lead.phone_1']) => {
+const response = (req, vars, fieldIds = ['outcome', 'reason', 'lead.id', 'lead.first_name', 'lead.last_name', 'lead.email', 'lead.phone_1', 'price']) => {
 
   const mimeType = selectMimeType(req.headers['Accept']);
 

--- a/lib/inbound/feedback.js
+++ b/lib/inbound/feedback.js
@@ -155,6 +155,7 @@ const response = (req, vars, fieldIds = ['outcome', 'reason', 'lead.id', 'lead.f
 response.variables = () => [
   { name: 'outcome', type: 'string', description: 'The outcome of the feedback request (default is success, meaning that the feedback was accepted)' },
   { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' },
+  { name: 'price', type: 'string', description: 'The price of the lead' },
   { name: 'lead.id', type: 'string', description: 'The lead identifier' },
   { name: 'lead.first_name', type: 'string', description: 'The consumer\'s first name' },
   { name: 'lead.last_name', type: 'string', description: 'The consumer\'s last name' },

--- a/lib/inbound/verbose.js
+++ b/lib/inbound/verbose.js
@@ -10,16 +10,12 @@ const response = (req, vars) => {
     fieldIds = _.keys(flat.flatten(appended, {safe: true}));
   }
 
-  fieldIds.push('outcome', 'reason', 'lead.id');
+  fieldIds.push('outcome', 'reason', 'lead.id', 'price');
 
   return inbound.response(req, vars, fieldIds);
 };
 
-response.variables = () => [
-  { name: 'lead.id', type: 'string', description: 'The lead identifier that the source should reference' },
-  { name: 'outcome', type: 'string', description: 'The outcome of the transaction (default is success)' },
-  { name: 'reason', type: 'string', description: 'If the outcome was a failure, this is the reason' }
-];
+response.variables = inbound.response.variables;
 
 module.exports = {
   name: 'Standard Verbose',

--- a/test/inbound/classic-spec.js
+++ b/test/inbound/classic-spec.js
@@ -3,32 +3,45 @@ const integration = require('../../lib/inbound/classic');
 
 describe('Classic Inbound Response', () => {
 
-  const vars = {
-    lead: { id: '123' },
-    outcome: 'Failure',
-    reason: 'bad!'
-  };
+  beforeEach(() => {
+    this.vars = {
+      lead: { id: '123' },
+      outcome: 'Failure',
+      reason: 'bad!'
+    };
+  });
+
 
   it('should respond with 201', () => {
-    const res = integration.response(baseRequest('application/json'), vars);
+    const res = integration.response(baseRequest('application/json'), this.vars);
     assert.deepEqual(res.status, 201);
   });
 
   it('should respond with xml', () => {
-    const res = integration.response(baseRequest('application/json'), vars);
-    assert.deepEqual(res.headers, {'Content-Type': 'application/xml', 'Content-Length': 253});
+    const res = integration.response(baseRequest('application/json'), this.vars);
+    assert.deepEqual(res.headers, {'Content-Type': 'application/xml', 'Content-Length': 264});
   });
 
   it('should correctly parse failure outcome', () => {
-    const res = integration.response(baseRequest('application/json'), vars);
+    const res = integration.response(baseRequest('application/json'), this.vars);
     assert.deepEqual(res.body, nonSuccessBody);
   });
 
   it('should correctly parse success outcome', () => {
-    vars.outcome = 'Success';
-    delete vars.reason;
+    this.vars.outcome = 'Success';
+    this.vars.price = 1.5;
+    delete this.vars.reason;
 
-    const res = integration.response(baseRequest('application/json'), vars);
+    const res = integration.response(baseRequest('application/json'), this.vars);
+    assert.deepEqual(res.body, successBody);
+  });
+
+  it('should capture price variable', () => {
+    this.vars.outcome = 'Success';
+    delete this.vars.reason;
+    this.vars.price = 1.5;
+
+    const res = integration.response(baseRequest('application/json'), this.vars);
     assert.deepEqual(res.body, successBody);
   });
 });
@@ -55,6 +68,7 @@ const successBody = `<!DOCTYPE response SYSTEM "https://app.leadconduit.com/dtd/
   <url>
     <![CDATA[https://app.leadconduit.com/leads?id=123]]>
   </url>
+  <price>1.5</price>
 </response>`;
 
 const nonSuccessBody = `<!DOCTYPE response SYSTEM "https://app.leadconduit.com/dtd/response-v2-basic.dtd">
@@ -65,4 +79,5 @@ const nonSuccessBody = `<!DOCTYPE response SYSTEM "https://app.leadconduit.com/d
   <url>
     <![CDATA[https://app.leadconduit.com/leads?id=123]]>
   </url>
+  <price/>
 </response>`;

--- a/test/inbound/classic-spec.js
+++ b/test/inbound/classic-spec.js
@@ -19,7 +19,7 @@ describe('Classic Inbound Response', () => {
 
   it('should respond with xml', () => {
     const res = integration.response(baseRequest('application/json'), this.vars);
-    assert.deepEqual(res.headers, {'Content-Type': 'application/xml', 'Content-Length': 264});
+    assert.deepEqual(res.headers, {'Content-Type': 'application/xml', 'Content-Length': 272});
   });
 
   it('should correctly parse failure outcome', () => {
@@ -31,15 +31,6 @@ describe('Classic Inbound Response', () => {
     this.vars.outcome = 'Success';
     this.vars.price = 1.5;
     delete this.vars.reason;
-
-    const res = integration.response(baseRequest('application/json'), this.vars);
-    assert.deepEqual(res.body, successBody);
-  });
-
-  it('should capture price variable', () => {
-    this.vars.outcome = 'Success';
-    delete this.vars.reason;
-    this.vars.price = 1.5;
 
     const res = integration.response(baseRequest('application/json'), this.vars);
     assert.deepEqual(res.body, successBody);
@@ -79,5 +70,5 @@ const nonSuccessBody = `<!DOCTYPE response SYSTEM "https://app.leadconduit.com/d
   <url>
     <![CDATA[https://app.leadconduit.com/leads?id=123]]>
   </url>
-  <price/>
+  <price>0</price>
 </response>`;

--- a/test/inbound/feedback-spec.js
+++ b/test/inbound/feedback-spec.js
@@ -159,6 +159,7 @@ describe('Inbound feedback', () => {
             id: '123',
             email: 'foo@bar.com'
           },
+          price: 1.5,
           outcome: 'failure',
           reason: 'bad!'
         };
@@ -167,8 +168,8 @@ describe('Inbound feedback', () => {
       it('should respond with json', () => {
         const res = integration.response(baseRequest('application/json'), vars);
         assert.equal(res.status, 201);
-        assert.deepEqual(res.headers, {'Content-Type': 'application/json', 'Content-Length': 79});
-        assert.equal(res.body, '{"outcome":"failure","reason":"bad!","lead":{"id":"123","email":"foo@bar.com"}}');
+        assert.deepEqual(res.headers, {'Content-Type': 'application/json', 'Content-Length': 91});
+        assert.equal(res.body, '{"outcome":"failure","reason":"bad!","lead":{"id":"123","email":"foo@bar.com"},"price":1.5}');
       });
 
       it('should default to json', () => {
@@ -186,15 +187,15 @@ describe('Inbound feedback', () => {
       it('should respond with text xml', () => {
         const res = integration.response(baseRequest('text/xml'), vars);
         assert.equal(res.status, 201);
-        assert.deepEqual(res.headers, {'Content-Type': 'text/xml', 'Content-Length': 210});
-        assert.equal(res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n    <first_name/>\n    <last_name/>\n    <email>foo@bar.com</email>\n    <phone_1/>\n  </lead>\n</result>');
+        assert.deepEqual(res.headers, {'Content-Type': 'text/xml', 'Content-Length': 231});
+        assert.equal(res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n    <first_name/>\n    <last_name/>\n    <email>foo@bar.com</email>\n    <phone_1/>\n  </lead>\n  <price>1.5</price>\n</result>');
       });
 
       it('should respond with application xml', () => {
         const res = integration.response(baseRequest(), vars);
         assert.equal(res.status, 201);
-        assert.deepEqual(res.headers, {'Content-Type': 'application/xml', 'Content-Length': 210});
-        assert.equal(res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n    <first_name/>\n    <last_name/>\n    <email>foo@bar.com</email>\n    <phone_1/>\n  </lead>\n</result>');
+        assert.deepEqual(res.headers, {'Content-Type': 'application/xml', 'Content-Length': 231});
+        assert.equal(res.body, '<?xml version="1.0"?>\n<result>\n  <outcome>failure</outcome>\n  <reason>bad!</reason>\n  <lead>\n    <id>123</id>\n    <first_name/>\n    <last_name/>\n    <email>foo@bar.com</email>\n    <phone_1/>\n  </lead>\n  <price>1.5</price>\n</result>');
       });
     });
 

--- a/test/inbound/verbose-spec.js
+++ b/test/inbound/verbose-spec.js
@@ -19,7 +19,8 @@ describe('Inbound Verbose Response', () => {
             outcome: 'success'
           }
         }
-      }
+      },
+      price: 1.5
     };
   });
 
@@ -34,9 +35,9 @@ describe('Inbound Verbose Response', () => {
       status: 201,
       headers: {
         'Content-Type': 'application/json',
-        'Content-Length': 162
+        'Content-Length': 174
       },
-      body: '{"appended":{"briteverify":{"email":{"status":"valid","disposable":"false","role_address":"false","outcome":"success"}}},"outcome":"success","lead":{"id":"1234"}}'
+      body: '{"appended":{"briteverify":{"email":{"status":"valid","disposable":"false","role_address":"false","outcome":"success"}}},"outcome":"success","lead":{"id":"1234"},"price":1.5}'
     };
     assert.deepEqual(integration.response(req, this.vars), expected);
   });
@@ -53,9 +54,9 @@ describe('Inbound Verbose Response', () => {
       status: 201,
       headers: {
         'Content-Type': 'application/xml',
-        'Content-Length': 359
+        'Content-Length': 380
       },
-      body: '<?xml version="1.0"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n</result>'
+      body: '<?xml version="1.0"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n  <price>1.5</price>\n</result>'
     };
     assert.deepEqual(integration.response(req, this.vars), expected);
   });
@@ -98,6 +99,7 @@ describe('Inbound Verbose Response', () => {
       lead: {
         id: '1234'
       },
+      price: 1.5,
       appended: {
         briteverify: {
           email: {
@@ -114,9 +116,9 @@ describe('Inbound Verbose Response', () => {
       status: 201,
       headers: {
         'Content-Type': 'application/xml',
-        'Content-Length': 390
+        'Content-Length': 411
       },
-      body: '<?xml version="1.0"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n        <billable>1</billable>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n</result>'
+      body: '<?xml version="1.0"?>\n<result>\n  <appended>\n    <briteverify>\n      <email>\n        <status>valid</status>\n        <disposable>false</disposable>\n        <role_address>false</role_address>\n        <outcome>success</outcome>\n        <billable>1</billable>\n      </email>\n    </briteverify>\n  </appended>\n  <outcome>success</outcome>\n  <reason/>\n  <lead>\n    <id>1234</id>\n  </lead>\n  <price>1.5</price>\n</result>'
     };
     assert.deepEqual(integration.response(req, vars), expected);
   });


### PR DESCRIPTION
This edits the `response` function of the classic, verbose, and feedback integrations.

This pr is slightly dependent on [similar changes](https://github.com/activeprospect/leadconduit-integration-default/pull/44) `-default` repo.