### PR TITLE
fix verbose response with numeric JSON key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [1.2.3]
+### Fixed
+- Bump version of `leadconduit-default` to fix verbose response for JSON with numeric ID ([ch23913](https://app.clubhouse.io/active-prospect/story/23913/pipedrive-form-post-delivery))
+- Add test to verify
+
 ## [1.2.1] - 2019-01-10
 ### Fixed
 - Fix failing test that was missed due to dependency differences

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "@activeprospect/indexer": "^1.3.1",
     "dotaccess": "^1.0.5",
     "flat": "^1.3.0",
-    "leadconduit-default": "^2.7.6",
+    "leadconduit-default": "^2.9.3",
     "leadconduit-integration": "^0.2.0",
     "lodash": "^4.17.15",
     "mime-content": "0.0.7",

--- a/test/inbound/verbose-spec.js
+++ b/test/inbound/verbose-spec.js
@@ -42,6 +42,32 @@ describe('Inbound Verbose Response', () => {
     assert.deepEqual(integration.response(req, this.vars), expected);
   });
 
+  it('should set appended fields correctly for JSON with a numeric ID', () => {
+    const req = {
+      uri: 'http://example.com',
+      headers: {
+        'Accept': 'application/json'
+      }
+    };
+
+    this.vars.appended.otherservice = {
+      user: {
+        12: {
+          foo: "bar"
+        }
+      }
+    };
+
+    const expected = {
+      status: 201,
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': 174
+      },
+      body: '{"appended":{"briteverify":{"email":{"status":"valid","disposable":"false","role_address":"false","outcome":"success"}},"otherservice":{"user":{"\'12\'":{"foo":"bar"}}}},"outcome":"success","lead":{"id":"1234"},"price":1.5}'
+    };
+    assert.equal(integration.response(req, this.vars).body, expected.body);
+  });
 
   it('should set appended fields correctly in XML response', () => {
     const req = {


### PR DESCRIPTION
## Description of the change

update minimum required leadconduit-default dependency; add test to verify numeric JSON key fix

(Tests failing until `leadconduit-default` fix is published.)

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Configuration change
- [ ] Technical Debt
- [ ] Documentation

## Related tickets

https://app.clubhouse.io/active-prospect/story/23913/pipedrive-form-post-delivery

## Checklists

### Development and Testing

- [ ]  Lint rules pass locally.
- [x]  The code changed/added as part of this pull request has been covered with tests, or this PR does not alter production code.
- [x]  All tests related to the changed code pass in development, or tests are not applicable.

### Code Review

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached.
- [ ]  At least two engineers have been added as "Reviewers" on the pull request.
- [ ]  Changes have been reviewed by at least two other engineers who did not write the code.
- [ ]  This branch has been rebased off master to be current.

### Tracking 
- [ ]  Issue from Clubhouse has a link to this pull request.
- [ ]  This PR has a link to the issue in Clubhouse.

### QA
- [ ]  This branch has been deployed to staging and tested.
